### PR TITLE
Allow wav, flac, msgpack type optional files

### DIFF
--- a/data/users/content.json
+++ b/data/users/content.json
@@ -16,7 +16,7 @@
   "permission_rules": {
    ".*": {
     "files_allowed": "data.json",
-    "files_allowed_optional": ".+mp3",
+    "files_allowed_optional": ".*.(mp3|flac|wav|msgpack)",
     "max_size": 50000
    }
   },


### PR DESCRIPTION
.msgpack for media files, including the media files that have been uploaded, will be generated when user submits a new file.